### PR TITLE
Delete method enableXcode11ReleaseNotesWorkarounds()

### DIFF
--- a/Sources/Mendoza/CommandLineProxy/CommandLineSimulators.swift
+++ b/Sources/Mendoza/CommandLineProxy/CommandLineSimulators.swift
@@ -131,13 +131,7 @@ extension CommandLineProxy {
         func enableLowQualityGraphicOverrides() throws {
             _ = try executer.execute("defaults write com.apple.iphonesimulator GraphicsQualityOverride 10")
         }
-
-        func enableXcode11ReleaseNotesWorkarounds(on simulator: Simulator) throws {
-            // See release notes workarounds: https://developer.apple.com/documentation/xcode_release_notes/xcode_11_release_notes?language=objc
-            // These settings are hot loaded no reboot of the device is necessary
-            _ = try? executer.execute("xcrun simctl spawn '\(simulator.id)' defaults write com.apple.springboard FBLaunchWatchdogScale 2")
-        }
-
+        
         func enableXcode13Workarounds(on simulator: Simulator) throws {
             // See https://developer.apple.com/forums/thread/683277?answerId=682047022#682047022
             let path = "\(simulatorSettingsPath(for: simulator))/com.apple.suggestions.plist"

--- a/Sources/Mendoza/Operations/SimulatorSetupOperation.swift
+++ b/Sources/Mendoza/Operations/SimulatorSetupOperation.swift
@@ -108,7 +108,6 @@ class SimulatorSetupOperation: BaseOperation<[(simulator: Simulator, node: Node)
                 bootQueue.waitUntilAllOperationsAreFinished()
 
                 for nodeSimulator in nodeSimulators {
-                    try proxy.enableXcode11ReleaseNotesWorkarounds(on: nodeSimulator)
                     try proxy.enableXcode13Workarounds(on: nodeSimulator)
                     try proxy.disableSlideToType(on: nodeSimulator)
 


### PR DESCRIPTION
Delete method enableXcode11ReleaseNotesWorkarounds().
It does not work. Return error: "Could not write domain com.apple.springboard; exiting"